### PR TITLE
improve compatibility with new Cordova 9.0.0

### DIFF
--- a/patch.js
+++ b/patch.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 module.exports = function (context) {
-    var fs = context.requireCordovaModule('fs'),
-        path = context.requireCordovaModule('path'),
+    var fs = require('fs'),
+        path = require('path'),
         platformRoot = path.join(context.opts.projectRoot, 'platforms/android'),
         manifestFile = path.join(platformRoot, 'AndroidManifest.xml');
 


### PR DESCRIPTION
New cordova 9 fails to compile as shown next:

Using "requireCordovaModule" to load non-cordova module "fs" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.

Remplaced requireCordovaModule to export solves the incompatibility.